### PR TITLE
feat: capture `the` or `of` separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Tests](https://github.com/natelandau/datefind/actions/workflows/test.yml/badge.svg)](https://github.com/natelandau/datefind/actions/workflows/test.yml) [![codecov](https://codecov.io/gh/natelandau/datefind/graph/badge.svg?token=CXstf6zblD)](https://codecov.io/gh/natelandau/datefind)
+
 # datefind
 
 A python module for locating dates within text. Use this package to search for dates and convert them to datetime objects.
@@ -26,7 +28,6 @@ from datefind import find_dates
 
 string = "2024-01-01 and 2024-01-02"
 
-
 for date in find_dates(string, tz="America/New_York"):
     print(date)
 
@@ -34,13 +35,13 @@ for date in find_dates(string, tz="America/New_York"):
     date=datetime.datetime(2024, 1, 1, 0, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
     text='2024-01-01 and 2024-01-02',
     match='2024-01-01',
-    span=(0, 9)
+    span=(0, 10)
     )
 >>> Date(
     date=datetime.datetime(2024, 1, 2, 0, 0, tzinfo=zoneinfo.ZoneInfo(key='America/New_York')),
     text='2024-01-01 and 2024-01-02',
     match='2024-01-02',
-    span=(15, 24)
+    span=(15, 25)
     )
 ```
 

--- a/src/datefind/utils/date_factory.py
+++ b/src/datefind/utils/date_factory.py
@@ -36,6 +36,7 @@ MM_FLEXIBLE = rf"(?P<month>{MM_FLEXIBLE})"
 MONTH_AS_TEXT = f"(?P<month_as_text>{MONTH})"
 NEXT_WEEK = rf"(?P<next_week>{NEXT_WEEK})"
 SEPARATOR = rf"[{SEP_CHARS}]*?"
+MONTH_DAY_SEPARATOR = rf"{SEPARATOR}(?:the|of)?{SEPARATOR}"
 START = rf"(?<![0-9]|[0-9][{SEP_CHARS}])"
 TODAY = rf"(?P<today>{TODAY})"
 TOMORROW = rf"(?P<tomorrow>{TOMORROW})"
@@ -58,7 +59,7 @@ YYYY_MONTH_DD = rf"""
 DD_MONTH_YYYY = rf"""
     {START}
     ({DD_FLEXIBLE}|{DD_AS_TEXT})
-    {SEPARATOR}
+    {MONTH_DAY_SEPARATOR}
     {MONTH_AS_TEXT}
     {SEPARATOR}
     {YYYY}
@@ -67,7 +68,7 @@ DD_MONTH_YYYY = rf"""
 MONTH_DD_YYYY = rf"""
     {START}
     {MONTH_AS_TEXT}
-    {SEPARATOR}
+    {MONTH_DAY_SEPARATOR}
     ({DD_FLEXIBLE}|{DD_AS_TEXT})
     {SEPARATOR}
     {YYYY}

--- a/tests/test_datefind.py
+++ b/tests/test_datefind.py
@@ -25,12 +25,13 @@ def test_raise_error_on_invalid_timezone():
     ("text", "first", "expected"),
     [
         pytest.param(
-            "march twenty second 2025 and sep. thirteenth 1999 and also DEC second 2024",
+            "march twenty second 2025 and sep. thirteenth 1999 and also DEC second 2024. July the fourth 2023",
             "month",
             [
                 datetime(2025, 3, 22, tzinfo=ZoneInfo("UTC")),
                 datetime(1999, 9, 13, tzinfo=ZoneInfo("UTC")),
                 datetime(2024, 12, 2, tzinfo=ZoneInfo("UTC")),
+                datetime(2023, 7, 4, tzinfo=ZoneInfo("UTC")),
             ],
             id="MONTH-NUMBER-YYYY",
         ),
@@ -89,11 +90,12 @@ def test_raise_error_on_invalid_timezone():
             id="MONTH-DD-YYYY",
         ),
         pytest.param(
-            "foo 10-January-2024 bar and 1-april-2024",
+            "foo 10-January-2024 bar and 1-april-2024. twenty fifth of august 1999",
             "month",
             [
                 datetime(2024, 1, 10, tzinfo=ZoneInfo("UTC")),
                 datetime(2024, 4, 1, tzinfo=ZoneInfo("UTC")),
+                datetime(1999, 8, 25, tzinfo=ZoneInfo("UTC")),
             ],
             id="DD-MONTH-YYYY",
         ),


### PR DESCRIPTION
correctly capture dates such as `twenty fifth of January` or `july the fourth`